### PR TITLE
Allow :email field to be sent on creating an order

### DIFF
--- a/lib/ship_hero/models/order_shipping_address.rb
+++ b/lib/ship_hero/models/order_shipping_address.rb
@@ -12,5 +12,6 @@ module ShipHero
     property :country_code, coerce: String
     property :address1, coerce: String
     property :address2, coerce: String
+    property :email, coerce: String
   end
 end


### PR DESCRIPTION
The class could not coerce the property :shipping_address from Hash to
ShipHero::OrderShippingAddress becasue the property 'email' was not
defined for ShipHero::OrderShippingAddress.